### PR TITLE
don't track the current user by default

### DIFF
--- a/lib/maglev/config.rb
+++ b/lib/maglev/config.rb
@@ -100,7 +100,7 @@ module MagLev
         @default_options = HashWithIndifferentAccess.new(
           enhanced_serialize: false,
           unique: true,
-          current_user: true,
+          current_user: false,
           timeout: nil,
           reliable: false,
           listeners: true,

--- a/lib/maglev/rspec/config.rb
+++ b/lib/maglev/rspec/config.rb
@@ -6,7 +6,7 @@ module MagLev
           default_options: HashWithIndifferentAccess.new(
             enhanced_serialize: true,
             unique: false,
-            current_user: true,
+            current_user: false,
             timeout: nil,
             reliable: false,
             listeners: :inherit,

--- a/spec/active_job/current_user_spec.rb
+++ b/spec/active_job/current_user_spec.rb
@@ -37,4 +37,10 @@ describe MagLev::ActiveJob::CurrentUser do
     # double check that the current user was actually restored properly
     expect(User.current).to eq user
   end
+
+  it 'should not track current user by default' do
+    CurrentUserJob.user = user
+    CurrentUserJob.perform_later
+    expect(CurrentUserJob.user).to be_nil
+  end
 end


### PR DESCRIPTION
I guess the spec isn't really necessary since it's configured differently for testing. Would you rather I remove the spec or extend the main config options? 