### PR TITLE
Do Not Cache Listeners

### DIFF
--- a/lib/maglev/active_job/listeners.rb
+++ b/lib/maglev/active_job/listeners.rb
@@ -12,7 +12,7 @@ module MagLev
             # if inherit is set then that indicates that we should use the existing set of listeners instead
             # of assuming the defaults on the sidekiq server
             if extended_options['listeners'] == :inherit
-              extended_options['listeners'] = Broadcaster.instance.listeners.map {|l| l.class.name }
+              extended_options['listeners'] = Broadcaster.instance.listener_instances.map {|l| l.class.name }
             end
           end
         end

--- a/lib/maglev/config.rb
+++ b/lib/maglev/config.rb
@@ -129,7 +129,6 @@ module MagLev
       attr_reader :registrations
 
       def registrations=(value)
-        @registration_classes = nil
         @registrations = value.compact
       end
 
@@ -150,12 +149,6 @@ module MagLev
         @registrations = []
         @broadcast_mode = :specified
         @async_listeners = true
-      end
-
-      def registration_classes
-        registrations.map do |r|
-          r.is_a?(Class) ? r : Object.const_get(r)
-        end
       end
     end
   end

--- a/lib/maglev/config.rb
+++ b/lib/maglev/config.rb
@@ -153,7 +153,7 @@ module MagLev
       end
 
       def registration_classes
-        @registration_classes ||= registrations.map do |r|
+        registrations.map do |r|
           r.is_a?(Class) ? r : Object.const_get(r)
         end
       end

--- a/lib/maglev/listeners/broadcaster.rb
+++ b/lib/maglev/listeners/broadcaster.rb
@@ -43,11 +43,11 @@ module MagLev
     end
 
     def default_listeners
-      @default_listeners ||= map_to_listener_instances(MagLev.config.listeners.registration_classes)
+      map_to_listener_instances(MagLev.config.listeners.registration_classes)
     end
 
     def listeners
-      @listeners ||= Set.new(default_listeners)
+      Set.new(default_listeners)
     end
 
     def listen(*listeners)

--- a/lib/maglev/listeners/broadcaster.rb
+++ b/lib/maglev/listeners/broadcaster.rb
@@ -43,23 +43,33 @@ module MagLev
     end
 
     def default_listeners
-      map_to_listener_instances(MagLev.config.listeners.registration_classes)
+      @default_listeners ||= MagLev.config.listeners.registrations.map(&:to_s)
     end
 
-    def listeners
-      Set.new(default_listeners)
+    def listener_names
+      @listener_names ||= Set.new(default_listeners)
+    end
+
+    def listener_classes
+      listener_names.map do | listener |
+        Object.const_get(listener)
+      end
+    end
+
+    def listener_instances
+      map_to_listener_instances(listener_classes)
     end
 
     def listen(*listeners)
-      listeners = map_to_listener_instances(listeners) - self.listeners.to_a
-      self.listeners.merge(listeners)
+      listener_names = listeners.map(&:to_s) - self.listener_names.to_a
+      self.listener_names.merge(listener_names)
 
       # if a block is given we will only listen until the block is called
       if block_given?
         begin
           yield
         ensure
-          self.listeners.subtract(listeners)
+          self.listener_names.subtract(listeners)
         end
       end
     end
@@ -79,15 +89,15 @@ module MagLev
     # ignores the given listeners. If a block is provided (recommended) then it will only
     # ignore the listenres for the duration of the block execution.
     def ignore(*listeners)
-      listeners = map_to_listener_instances(listeners) & self.listeners.to_a
-      self.listeners.subtract(listeners)
+      listener_names = listeners.map(&:to_s) & self.listener_names.to_a
+      self.listener_names.subtract(listener_names)
 
       # if a block is given we will only listen until the block is called
       if block_given?
         begin
           yield
         ensure
-          self.listeners.merge(listeners)
+          self.listener_names.merge(listeners)
         end
       end
     end
@@ -130,7 +140,7 @@ module MagLev
     protected
 
     def broadcast_listeners
-      listeners.each do | listener |
+      listener_instances.each do | listener |
         if event.targets.empty? or event.targets.include?(listener.class)
           listened = false
 

--- a/spec/active_job/listeners_spec.rb
+++ b/spec/active_job/listeners_spec.rb
@@ -6,8 +6,7 @@ class ListenerJob < MagLev::ActiveJob::Base
   cattr_accessor :count
 
   def perform(*args)
-    # p MagLev.broadcaster.listeners
-    ListenerJob.count = MagLev.broadcaster.listeners.count
+    ListenerJob.count = MagLev.broadcaster.listener_instances.count
   end
 end
 
@@ -22,7 +21,7 @@ describe MagLev::ActiveJob::Listeners do
   context 'when manually listenining' do
     before do
       MagLev.broadcaster.listen(ListenerJob)
-      expect(MagLev.broadcaster.listeners.count).to eq 1
+      expect(MagLev.broadcaster.listener_instances.count).to eq 1
     end
 
     it 'should not set listeners when they are turned off' do
@@ -37,7 +36,7 @@ describe MagLev::ActiveJob::Listeners do
   end
 
   it 'should configure registered listeners when true', listeners: ListenerJob do
-    expect(MagLev.broadcaster.listeners.count).to eq 1
+    expect(MagLev.broadcaster.listener_instances.count).to eq 1
     job.enqueue(listeners: true)
     expect(ListenerJob.count).to eq 1
   end

--- a/spec/listeners/broadcaster_spec.rb
+++ b/spec/listeners/broadcaster_spec.rb
@@ -21,7 +21,7 @@ end
 class AsyncListener
   def user_created_async(user)
     # only update if the lister was properly included, in order to check that they are infact attached
-    if MagLev.broadcaster.listeners.any? {|l| l.class.name == 'AsyncListener'}
+    if MagLev.broadcaster.listener_instances.any? {|l| l.class.name == 'AsyncListener'}
       user.name = 'async'
       user.save!
     end
@@ -36,8 +36,8 @@ describe MagLev::Broadcaster do
   context 'with specified broadcast_mode', listeners: SharedListener do
     MagLev.config.listeners.broadcast_mode = :specified
 
-    describe '#listeners' do
-      its(:listeners) { should_not be_empty }
+    describe '#listener_instances' do
+      its(:listener_instances) { should_not be_empty }
     end
 
     describe '#broadcast' do


### PR DESCRIPTION
Defer the class actualization until we need it so as to not interfere with reloading