### PR TITLE
Make sure RequestStore is cleared after each job

### DIFF
--- a/maglev.gemspec
+++ b/maglev.gemspec
@@ -31,6 +31,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'redis'
   spec.add_dependency 'activejob', '~> 5.2.0'
   spec.add_dependency 'request_store'
+  spec.add_dependency 'request_store-sidekiq'
   spec.add_dependency 'activesupport', '~> 5.2.0'
   spec.add_dependency 'concurrent-ruby'
   spec.add_development_dependency 'rails', '~> 5.2.0'


### PR DESCRIPTION
`RequestStore` uses Rack middleware, so it's not cleared when Rack is not involved, like background jobs. This gem adds a Sidekiq server middleware to ensure the store is cleared after each job.

This should fix the leak.